### PR TITLE
Cross build for Play 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ resolvers += Resolver.bintrayRepo("hmrc", "releases")
 libraryDependencies += "uk.gov.hmrc" %% "play-json-union-formatter" % "x.x.x"
 ```
 
-If your microservice is using Play 2.5, use version 1.7.0 or older. Versions > 1.7.0 only support Play 2.6
+If your microservice is using Play 2.5, use version 1.7.0 or older. Versions > 1.7.0 only support Play 2.6 and above.
 
 ## Usage
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,19 +24,34 @@ import uk.gov.hmrc.versioning.SbtGitVersioning
 
 lazy val library = (project in file("."))
   .enablePlugins(SbtAutoBuildPlugin, SbtGitVersioning, SbtArtifactory)
+  .settings(PlayCrossCompilation.playCrossCompilationSettings)
   .settings(
     scalaVersion := "2.12.10",
     name := "play-json-union-formatter",
     majorVersion := 1,
     makePublicallyAvailableOnBintray := true,
     targetJvm := "jvm-1.8",
-    libraryDependencies ++= Seq(
-      "org.scalatest"     %% "scalatest" % "3.0.8"  % "test",
-      "uk.gov.hmrc"       %% "hmrctest"  % "3.9.0-play-26"  % "test",
-      "com.typesafe.play" %% "play-json" % "2.6.14"
-    ),
+    libraryDependencies ++= deps,
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases")
     )
   )
 
+val testDepsShared: Seq[ModuleID] = Seq(
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "org.pegdown"   %  "pegdown"   % "1.6.0" % "test",
+)
+
+val compileDepsPlay26: Seq[ModuleID] = Seq(
+  "com.typesafe.play" %% "play-json" % "2.6.14"
+)
+
+val compileDepsPlay27: Seq[ModuleID] = Seq(
+  "com.typesafe.play" %% "play-json" % "2.7.4"
+)
+
+val deps: Seq[ModuleID] = PlayCrossCompilation.dependencies(
+  play26 = compileDepsPlay26,
+  play27 = compileDepsPlay27,
+  shared = testDepsShared
+)

--- a/project/PlayCrossCompilation.scala
+++ b/project/PlayCrossCompilation.scala
@@ -1,0 +1,4 @@
+import uk.gov.hmrc.playcrosscompilation.AbstractPlayCrossCompilation
+import uk.gov.hmrc.playcrosscompilation.PlayVersion.{Play26}
+
+object PlayCrossCompilation extends AbstractPlayCrossCompilation(defaultPlayVersion = Play26)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,8 @@
 resolvers += Resolver.url("hmrc-sbt-plugin-releases", url("https://dl.bintray.com/hmrc/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.5.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-play-cross-compilation" % "1.0.0")


### PR DESCRIPTION
This PR adds cross building for Play 2.6 and Play 2.7. I also removed the dependency on the hmrctest library as it is deprecated and doesn't appear to be used in this repo anyway.