### PR TITLE
CGBA-40 Support for recursive union types

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/json/Union.scala
+++ b/src/main/scala/uk/gov/hmrc/play/json/Union.scala
@@ -21,17 +21,20 @@ import scala.reflect.ClassTag
 
 class Union[A](typeField: String, readWith: PartialFunction[String, JsValue => JsResult[A]], writeWith: PartialFunction[A, JsObject]) {
 
-  def and[B <: A](typeTag: String)(implicit ct: ClassTag[B], f: OFormat[B]) = {
+  def andLazy[B <: A](typeTag: String, fmt: => OFormat[B])(implicit ct: ClassTag[B]) = {
     val readCase: PartialFunction[String, JsValue => JsResult[A]] = {
-      case `typeTag` => jsValue: JsValue => Json.fromJson(jsValue)(f).asInstanceOf[JsResult[A]]
+      case `typeTag` => jsValue: JsValue => Json.fromJson(jsValue)(fmt).asInstanceOf[JsResult[A]]
     }
 
     val writeCase: PartialFunction[A, JsObject] = {
-      case value: B => Json.toJsObject(value)(f) ++ Json.obj(typeField -> typeTag)
+      case value: B => Json.toJsObject(value)(fmt) ++ Json.obj(typeField -> typeTag)
     }
 
     new Union(typeField, readWith.orElse(readCase), writeWith.orElse(writeCase))
   }
+
+  def and[B <: A](typeTag: String)(implicit ct: ClassTag[B], f: OFormat[B]) =
+    andLazy(typeTag, f)
 
   private val defaultReads: PartialFunction[String, JsValue => JsResult[A]] = {
     case attemptedType => jsValue => JsError(__ \ typeField, s"$attemptedType is not a recognised $typeField")


### PR DESCRIPTION
This adds support for recursive union types, i.e. types where the union type itself occurs in one of the fields of the members.

Without using this approach we get either an UninitializedFieldError or StackOverFlowError when attempting to use Union with a recursive union type, depending upon whether we use `def` or `lazy val` to declare the formatters.

This is because the `and` function currently accepts the member `OFormat[A]` eagerly, so will attempt to refer to the parent formatter in its own definition.

You can test this by switching to `and` instead of `andLazy` in the RecursiveUnion format in the unit tests.

Unfortunately we have to use an interface like:

`.andLazy[Recursive]("RECURSIVE", Recursive.format)`

This is because by-name implicits are not supported in Scala 2.12. On Scala 2.13 we could write:

`.andLazy[Recursive]("RECURSIVE")`

and declare the `andLazy` function or even the original `and` function like this:

`def andLazy[B <: A](typeTag: String)(implicit ct: ClassTag[B], fmt: => OFormat[B])`